### PR TITLE
Extend Visual Format Language for layoutMarginsGuide and Safe Area

### DIFF
--- a/Classes/NorthLayout.swift
+++ b/Classes/NorthLayout.swift
@@ -11,6 +11,7 @@
     typealias Size = CGSize
     typealias LayoutPriority = UILayoutPriority
     typealias LayoutAxis = UILayoutConstraintAxis
+    typealias LayoutGuide = UILayoutGuide
     public typealias FormatOptions = NSLayoutFormatOptions
     extension View: LayoutPrioritizable {}
 
@@ -29,6 +30,7 @@
     typealias Size = NSSize
     typealias LayoutPriority = NSLayoutConstraint.Priority
     typealias LayoutAxis = NSLayoutConstraint.Orientation
+    typealias LayoutGuide = NSLayoutGuide
     public typealias FormatOptions = NSLayoutConstraint.FormatOptions
 
     public final class MinView: NSView, MinLayoutable {
@@ -55,43 +57,19 @@ extension View {
             self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: edgeDecomposed?.middle ?? format, options: options, metrics: metrics as [String : NSNumber]?, views: views))
             if !format.hasPrefix("V:") {
                 if let leftConnection = edgeDecomposed?.first, let leftView = views[leftConnection.2.name] {
-                    let anchor: NSLayoutXAxisAnchor = {
-                        switch leftConnection.0 {
-                        case .superview: return self.leftAnchor
-                        case .layoutMargin: return self.layoutMarginsGuide.leftAnchor
-                        }
-                    }()
-                    leftConnection.1.predicateList.constraints(lhs: leftView.leftAnchor, rhs:anchor, metrics: metrics)
+                    leftConnection.1.predicateList.constraints(lhs: leftView.leftAnchor, rhs: leftConnection.0.leftAnchor(for: self), metrics: metrics)
                 }
-
+                
                 if let rightConnection = edgeDecomposed?.last, let rightView = views[rightConnection.0.name] {
-                    let anchor: NSLayoutXAxisAnchor = {
-                        switch rightConnection.2 {
-                        case .superview: return self.rightAnchor
-                        case .layoutMargin: return self.layoutMarginsGuide.rightAnchor
-                        }
-                    }()
-                    rightConnection.1.predicateList.constraints(lhs: anchor, rhs: rightView.rightAnchor, metrics: metrics)
+                    rightConnection.1.predicateList.constraints(lhs: rightConnection.2.rightAnchor(for: self), rhs: rightView.rightAnchor, metrics: metrics)
                 }
             } else {
                 if let leftConnection = edgeDecomposed?.first, let leftView = views[leftConnection.2.name] {
-                    let anchor: NSLayoutYAxisAnchor = {
-                        switch leftConnection.0 {
-                        case .superview: return self.topAnchor
-                        case .layoutMargin: return self.layoutMarginsGuide.topAnchor
-                        }
-                    }()
-                    leftConnection.1.predicateList.constraints(lhs: leftView.topAnchor, rhs:anchor, metrics: metrics)
+                    leftConnection.1.predicateList.constraints(lhs: leftView.topAnchor, rhs: leftConnection.0.topAnchor(for: self), metrics: metrics)
                 }
-
+                
                 if let rightConnection = edgeDecomposed?.last, let rightView = views[rightConnection.0.name] {
-                    let anchor: NSLayoutYAxisAnchor = {
-                        switch rightConnection.2 {
-                        case .superview: return self.bottomAnchor
-                        case .layoutMargin: return self.layoutMarginsGuide.bottomAnchor
-                        }
-                    }()
-                    rightConnection.1.predicateList.constraints(lhs: anchor, rhs: rightView.bottomAnchor, metrics: metrics)
+                    rightConnection.1.predicateList.constraints(lhs: rightConnection.2.bottomAnchor(for: self), rhs: rightView.bottomAnchor, metrics: metrics)
                 }
             }
         }

--- a/Classes/NorthLayout.swift
+++ b/Classes/NorthLayout.swift
@@ -112,26 +112,19 @@ extension View {
             guard #available(iOS 11, *) else {
                 // iOS 10 layoutMarginsGuide does not follow to top/bottom layout guides nor safe area layout guides.
                 // we use the layout guides to contain views within them, i.e. do not allow to extend to the below of navbars/toolbars.
-
-                let topMarginGuide = UILayoutGuide()
-                let bottomMarginGuide = UILayoutGuide()
-                [topMarginGuide, bottomMarginGuide].forEach {view.addLayoutGuide($0)}
-                topMarginGuide.bottomAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor, constant: 8).isActive = true
-                bottomLayoutGuide.topAnchor.constraint(equalTo: bottomMarginGuide.topAnchor, constant: 8).isActive = true
+                // as top/bottom margin of root view of vc is zero, we replace both `||` and `|` to top/bottom layout guides
 
                 var vs = views
                 vs["topLayoutGuide"] = topLayoutGuide
-                vs["topMarginGuide"] = topMarginGuide
                 vs["bottomLayoutGuide"] = bottomLayoutGuide
-                vs["bottomMarginGuide"] = bottomMarginGuide
 
                 let autolayout = view.northLayoutFormat(metrics, vs, options: options)
 
                 return { (format: String) in
                     autolayout(!format.hasPrefix("V:") ? format : format
-                        .replacingOccurrences(of: "V:||", with: "V:[topMarginGuide]")
+                        .replacingOccurrences(of: "V:||", with: "V:[topLayoutGuide]")
                         .replacingOccurrences(of: "V:|", with: "V:[topLayoutGuide]")
-                        .replacingOccurrences(of: "||", with: "[bottomMarginGuide]")
+                        .replacingOccurrences(of: "||", with: "[bottomLayoutGuide]")
                         .replacingOccurrences(of: "|", with: "[bottomLayoutGuide]"))
                 }
             }

--- a/Classes/NorthLayout.swift
+++ b/Classes/NorthLayout.swift
@@ -58,7 +58,7 @@ extension View {
                     let anchor: NSLayoutXAxisAnchor = {
                         switch leftConnection.0 {
                         case .superview: return self.leftAnchor
-                        case .layoutMrgin: return self.layoutMarginsGuide.leftAnchor
+                        case .layoutMargin: return self.layoutMarginsGuide.leftAnchor
                         }
                     }()
                     leftConnection.1.predicateList.constraints(lhs: leftView.leftAnchor, rhs:anchor, metrics: metrics)
@@ -68,7 +68,7 @@ extension View {
                     let anchor: NSLayoutXAxisAnchor = {
                         switch rightConnection.2 {
                         case .superview: return self.rightAnchor
-                        case .layoutMrgin: return self.layoutMarginsGuide.rightAnchor
+                        case .layoutMargin: return self.layoutMarginsGuide.rightAnchor
                         }
                     }()
                     rightConnection.1.predicateList.constraints(lhs: anchor, rhs: rightView.rightAnchor, metrics: metrics)
@@ -78,7 +78,7 @@ extension View {
                     let anchor: NSLayoutYAxisAnchor = {
                         switch leftConnection.0 {
                         case .superview: return self.topAnchor
-                        case .layoutMrgin: return self.layoutMarginsGuide.topAnchor
+                        case .layoutMargin: return self.layoutMarginsGuide.topAnchor
                         }
                     }()
                     leftConnection.1.predicateList.constraints(lhs: leftView.topAnchor, rhs:anchor, metrics: metrics)
@@ -88,7 +88,7 @@ extension View {
                     let anchor: NSLayoutYAxisAnchor = {
                         switch rightConnection.2 {
                         case .superview: return self.bottomAnchor
-                        case .layoutMrgin: return self.layoutMarginsGuide.bottomAnchor
+                        case .layoutMargin: return self.layoutMarginsGuide.bottomAnchor
                         }
                     }()
                     rightConnection.1.predicateList.constraints(lhs: anchor, rhs: rightView.bottomAnchor, metrics: metrics)
@@ -129,7 +129,7 @@ extension View {
                     let anchor: NSLayoutXAxisAnchor = {
                         switch leftConnection.0 {
                         case .superview: return view.leftAnchor
-                        case .layoutMrgin: return view.layoutMarginsGuide.leftAnchor
+                        case .layoutMargin: return view.layoutMarginsGuide.leftAnchor
                         }
                     }()
                     leftConnection.1.predicateList.constraints(lhs: leftView.leftAnchor, rhs:anchor, metrics: metrics)
@@ -139,7 +139,7 @@ extension View {
                     let anchor: NSLayoutXAxisAnchor = {
                         switch rightConnection.2 {
                         case .superview: return view.rightAnchor
-                        case .layoutMrgin: return view.layoutMarginsGuide.rightAnchor
+                        case .layoutMargin: return view.layoutMarginsGuide.rightAnchor
                         }
                     }()
                     rightConnection.1.predicateList.constraints(lhs: anchor, rhs: rightView.rightAnchor, metrics: metrics)

--- a/Classes/NorthLayout.swift
+++ b/Classes/NorthLayout.swift
@@ -77,19 +77,28 @@ extension View {
                     .replacingOccurrences(of: "|", with: "[bottomLayoutGuide]"))
             }
 
-            guard #available(iOS 11, tvOS 11, *), useSafeArea else { return autolayoutWithVerticalGuides }
-            let safeAreaLayoutGuide = view.safeAreaLayoutGuide
-
             return { (format: String) in
                 let edgeDecomposed = try? VFL(format: format).edgeDecomposed(format: format)
                 autolayoutWithVerticalGuides(edgeDecomposed?.middle ?? format)
 
-                if let leftConnection = edgeDecomposed?.first, let leftView = views[leftConnection.1.name] {
-                    leftConnection.0.predicateList.constraints(lhs: leftView.leftAnchor, rhs: safeAreaLayoutGuide.leftAnchor, metrics: metrics)
+                if let leftConnection = edgeDecomposed?.first, let leftView = views[leftConnection.2.name] {
+                    let anchor: NSLayoutXAxisAnchor = {
+                        switch leftConnection.0 {
+                        case .superview: return view.leftAnchor
+                        case .layoutMrgin: return view.layoutMarginsGuide.leftAnchor
+                        }
+                    }()
+                    leftConnection.1.predicateList.constraints(lhs: leftView.leftAnchor, rhs:anchor, metrics: metrics)
                 }
 
-                if let rightConnection = edgeDecomposed?.last, let rightView = views[rightConnection.1.name] {
-                    rightConnection.0.predicateList.constraints(lhs: safeAreaLayoutGuide.rightAnchor, rhs: rightView.rightAnchor, metrics: metrics)
+                if let rightConnection = edgeDecomposed?.last, let rightView = views[rightConnection.0.name] {
+                    let anchor: NSLayoutXAxisAnchor = {
+                        switch rightConnection.2 {
+                        case .superview: return view.rightAnchor
+                        case .layoutMrgin: return view.layoutMarginsGuide.rightAnchor
+                        }
+                    }()
+                    rightConnection.1.predicateList.constraints(lhs: anchor, rhs: rightView.rightAnchor, metrics: metrics)
                 }
             }
         }

--- a/Classes/VFL.swift
+++ b/Classes/VFL.swift
@@ -93,6 +93,18 @@ extension VFL.Bound {
             return view
         case .layoutMargin:
             #if os(iOS) || os(tvOS)
+                guard #available(iOS 11, tvOS 11, *) else {
+                    // in iOS 10, reading layoutMarginsGuide when frame.size is zero and autolayout disabled
+                    // has side-effect causing layoutMargins not to work with margins.
+                    // workaround: simply enclose by setting false/true
+                    let prev = view.translatesAutoresizingMaskIntoConstraints
+                    if view.frame.size == .zero {
+                        view.translatesAutoresizingMaskIntoConstraints = false
+                    }
+                    let r = view.layoutMarginsGuide
+                    view.translatesAutoresizingMaskIntoConstraints = prev
+                    return r
+                }
                 return view.layoutMarginsGuide
             #else
                 // macOS cannot support layout margins. silently fall back to superview.

--- a/Classes/VFL.swift
+++ b/Classes/VFL.swift
@@ -87,3 +87,45 @@ extension VFL.PredicateList {
         return cs
     }
 }
+
+protocol Anchorable {
+    var leftAnchor: NSLayoutXAxisAnchor { get }
+    var rightAnchor: NSLayoutXAxisAnchor { get }
+    var topAnchor: NSLayoutYAxisAnchor { get }
+    var bottomAnchor: NSLayoutYAxisAnchor { get }
+}
+
+extension View: Anchorable {}
+extension LayoutGuide: Anchorable {}
+
+extension VFL.Bound {
+    private func anchorable(for view: View) -> Anchorable {
+        switch self {
+        case .superview:
+            return view
+        case .layoutMargin:
+            #if os(iOS) || os(tvOS)
+                return view.layoutMarginsGuide
+            #else
+                // macOS cannot support layout margins. silently fall back to superview.
+                return view
+            #endif
+        }
+    }
+
+    func leftAnchor(for view: View) -> NSLayoutXAxisAnchor {
+        return anchorable(for: view).leftAnchor
+    }
+
+    func rightAnchor(for view: View) -> NSLayoutXAxisAnchor {
+        return anchorable(for: view).rightAnchor
+    }
+
+    func topAnchor(for view: View) -> NSLayoutYAxisAnchor {
+        return anchorable(for: view).topAnchor
+    }
+
+    func bottomAnchor(for view: View) -> NSLayoutYAxisAnchor {
+        return anchorable(for: view).bottomAnchor
+    }
+}

--- a/Classes/VFL.swift
+++ b/Classes/VFL.swift
@@ -2,13 +2,13 @@ import Foundation
 
 extension VFL {
     /// decompose visual format into both side of edge connections and a middle remainder format string
-    func edgeDecomposed(format: String) throws -> (first: (Connection, VFL.View)?, middle: String, last: (Connection, VFL.View)?) {
+    func edgeDecomposed(format: String) throws -> (first: (Bound, Connection, VFL.View)?, middle: String, last: (VFL.View, Connection, Bound)?) {
         var middle = format
         let vfl = try VFL(format: format)
         guard case .h = vfl.orientation else { return (nil, format, nil) } // only support horizontals
 
-        let first = vfl.firstBound.map {($0, vfl.firstView)}
-        let last = vfl.lastBound.map {($0, vfl.lastView)}
+        let first = vfl.firstBound.map {($0.0, $0.1, vfl.firstView)}
+        let last = vfl.lastBound.map {(vfl.lastView, $0.0, $0.1)}
 
         // strip decomposed edge connections
         // we do not generate a format string from parsed VFL, for some reliability

--- a/Classes/VFL.swift
+++ b/Classes/VFL.swift
@@ -2,30 +2,18 @@ import Foundation
 
 extension VFL {
     /// decompose visual format into both side of edge connections and a middle remainder format string
-    func edgeDecomposed(format: String) throws -> (first: (Bound, Connection, VFL.View)?, middle: String, last: (VFL.View, Connection, Bound)?) {
-        var middle = format
-        let vfl = try VFL(format: format)
-
-        let first = vfl.firstBound.map {($0.0, $0.1, vfl.firstView)}
-        let last = vfl.lastBound.map {(vfl.lastView, $0.0, $0.1)}
-
+    func edgeDecomposed(format: String) -> String {
         // strip decomposed edge connections
         // we do not generate a format string from parsed VFL, for some reliability
         // instead, use a knowledge that first `[` and last `]` separate edge connections
-//        if first != nil {
-            middle = String(middle.drop {$0 != "["})
-//        }
-//        if last != nil {
-            middle = String(middle.reversed().drop {$0 != "]"}.reversed())
-//        }
+        let decomposed = format
+            .drop {$0 != "["}
+            .reversed().drop {$0 != "]"}.reversed()
 
-        let orientation: String
-        switch vfl.orientation {
-        case .h: orientation = "H:"
-        case .v: orientation = "V:"
+        switch orientation {
+        case .h: return "H:" + decomposed
+        case .v: return "V:" + decomposed
         }
-
-        return (first, orientation + middle, last)
     }
 }
 

--- a/Classes/VFL.swift
+++ b/Classes/VFL.swift
@@ -5,7 +5,6 @@ extension VFL {
     func edgeDecomposed(format: String) throws -> (first: (Bound, Connection, VFL.View)?, middle: String, last: (VFL.View, Connection, Bound)?) {
         var middle = format
         let vfl = try VFL(format: format)
-        guard case .h = vfl.orientation else { return (nil, format, nil) } // only support horizontals
 
         let first = vfl.firstBound.map {($0.0, $0.1, vfl.firstView)}
         let last = vfl.lastBound.map {(vfl.lastView, $0.0, $0.1)}
@@ -13,14 +12,20 @@ extension VFL {
         // strip decomposed edge connections
         // we do not generate a format string from parsed VFL, for some reliability
         // instead, use a knowledge that first `[` and last `]` separate edge connections
-        if first != nil {
+//        if first != nil {
             middle = String(middle.drop {$0 != "["})
-        }
-        if last != nil {
+//        }
+//        if last != nil {
             middle = String(middle.reversed().drop {$0 != "]"}.reversed())
+//        }
+
+        let orientation: String
+        switch vfl.orientation {
+        case .h: orientation = "H:"
+        case .v: orientation = "V:"
         }
 
-        return (first, middle, last)
+        return (first, orientation + middle, last)
     }
 }
 

--- a/Classes/VFLSyntax.swift
+++ b/Classes/VFLSyntax.swift
@@ -20,7 +20,7 @@ struct VFL {
 
     enum Bound: String {
         case superview = "|"
-        case layoutMrgin = "||" // NOTE: custom VFL element introduced in NorthLayout. indicates bound is layoutMarginsGuide, including Safe Area + spacing
+        case layoutMargin = "||" // NOTE: custom VFL element introduced in NorthLayout. indicates bound is layoutMarginsGuide, including Safe Area + spacing
     }
 
     struct Connection {
@@ -126,7 +126,7 @@ extension VFL {
             <*> zeroOrMore(char(",") *> VFL.Predicate.parser) <* char(")")
         let predicateList: Parser<Character, VFL.PredicateList> = {.simplePredicate($0)} <^> simplePredicate
             <|> {.predicateListWithParens($0)} <^> predicateListWithParens
-        let bound: Parser<Character, VFL.Bound> = {_ in VFL.Bound.layoutMrgin} <^> string(VFL.Bound.layoutMrgin.rawValue)
+        let bound: Parser<Character, VFL.Bound> = {_ in VFL.Bound.layoutMargin} <^> string(VFL.Bound.layoutMargin.rawValue)
             <|> {_ in .superview} <^> string(VFL.Bound.superview.rawValue)
         let connection = (VFL.Connection.init) <^> (char("-") *> predicateList <* char("-")
             <|> {_ in VFL.PredicateList.simplePredicate(.positiveNumber(8))} <^> char("-")

--- a/Classes/VFLSyntax.swift
+++ b/Classes/VFLSyntax.swift
@@ -5,17 +5,22 @@ import FootlessParser
 // currently only needed for VFL.edgeDecomposed for Safe Area handling
 struct VFL {
     let orientation: Orientation
-    let firstBound: Connection?
+    let firstBound: (Bound, Connection)?
     let firstView: View
     let views: [(Connection, View)]
     var lastView: View {return views.last?.1 ?? firstView}
-    let lastBound: Connection?
+    let lastBound: (Connection, Bound)?
 
     enum Orientation {case h, v}
 
     struct View {
         let name: String
         let predicateListWithParens: [Predicate]
+    }
+
+    enum Bound: String {
+        case superview = "|"
+        case layoutMrgin = "||" // NOTE: custom VFL element introduced in NorthLayout. indicates bound is layoutMarginsGuide, including Safe Area + spacing
     }
 
     struct Connection {
@@ -121,7 +126,8 @@ extension VFL {
             <*> zeroOrMore(char(",") *> VFL.Predicate.parser) <* char(")")
         let predicateList: Parser<Character, VFL.PredicateList> = {.simplePredicate($0)} <^> simplePredicate
             <|> {.predicateListWithParens($0)} <^> predicateListWithParens
-        let superview = char("|")
+        let bound: Parser<Character, VFL.Bound> = {_ in VFL.Bound.layoutMrgin} <^> string(VFL.Bound.layoutMrgin.rawValue)
+            <|> {_ in .superview} <^> string(VFL.Bound.superview.rawValue)
         let connection = (VFL.Connection.init) <^> (char("-") *> predicateList <* char("-")
             <|> {_ in VFL.PredicateList.simplePredicate(.positiveNumber(8))} <^> char("-")
             <|> {_ in VFL.PredicateList.simplePredicate(.positiveNumber(0))} <^> string(""))
@@ -133,9 +139,9 @@ extension VFL {
             <|> {_ in .h} <^> (string("H:") <|> string(""))
         return curry(VFL.init)
             <^> orientation
-            <*> optional(superview *> connection)
+            <*> optional(tuple <^> bound <*> connection)
             <*> view
             <*> views
-            <*> optional(connection <* superview)
+            <*> optional(tuple <^> connection <*> bound)
     }
 }

--- a/Example/NorthLayout-ios/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/NorthLayout-ios/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,16 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
     },
     {
       "idiom" : "ipad",
@@ -64,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/NorthLayout-ios/ViewController.swift
+++ b/Example/NorthLayout-ios/ViewController.swift
@@ -19,47 +19,66 @@ private func colorImage(_ color: UIColor) -> UIImage {
     return image
 }
 
+private let iconWidth: CGFloat = 32
 
 class ViewController: UIViewController {
+    let headerView = HeaderView()
+
+    let iconView: UIImageView = {
+        let v = UIImageView(image: colorImage(UIColor(red: 0.63, green: 0.9, blue: 1, alpha: 1)))
+        v.layer.cornerRadius = iconWidth / 2
+        v.clipsToBounds = true
+        return v
+    }()
+
+    let nameLabel: UILabel = {
+        let l = UILabel()
+        l.text = "Name"
+        return l
+    }()
+
+    let dateLabel: UILabel = {
+        let l = UILabel()
+        l.text = "1 min ago"
+        l.font = UIFont.systemFont(ofSize: 12)
+        l.textColor = .lightGray
+        l.textAlignment = .right
+        return l
+    }()
+
+
+    let textLabel: UILabel = {
+        let l = UILabel()
+        l.text = "Some text go here"
+        return l
+    }()
+
+    let favButton: UIButton = {
+        let b = UIButton(type: .system)
+        b.setTitle("⭐️", for: [])
+        b.backgroundColor = UIColor(red: 0.17, green: 0.29, blue: 0.45, alpha: 1.0)
+        b.setTitleColor(.white, for: [])
+        b.layer.cornerRadius = 4
+        b.clipsToBounds = true
+        b.addTarget(self, action: #selector(fav), for: .touchUpInside)
+        return b
+    }()
+
+    let replyButton: UIButton = {
+        let b = UIButton(type: .system)
+        b.setTitle("Nav", for: [])
+        b.backgroundColor = UIColor(red: 0.17, green: 0.29, blue: 0.45, alpha: 1.0)
+        b.setTitleColor(.white, for: [])
+        b.layer.cornerRadius = 4
+        b.clipsToBounds = true
+        b.addTarget(self, action: #selector(nav), for: .touchUpInside)
+        return b
+    }()
+
     override func loadView() {
         super.loadView()
-
         view.backgroundColor = .white
 
-        let iconView = UIImageView(image: colorImage(UIColor(red: 0.63, green: 0.9, blue: 1, alpha: 1)))
-        let iconWidth = CGFloat(32)
-        iconView.layer.cornerRadius = iconWidth / 2
-        iconView.clipsToBounds = true
-        
-        let nameLabel = UILabel()
-        nameLabel.text = "Name"
-        
-        let dateLabel = UILabel()
-        dateLabel.text = "1 min ago"
-        dateLabel.font = UIFont.systemFont(ofSize: 12)
-        dateLabel.textColor = .lightGray
-        dateLabel.textAlignment = .right
-        
-        let textLabel = UILabel()
-        textLabel.text = "Some text go here"
-        
-        let favButton = UIButton(type: .system)
-        favButton.setTitle("⭐️", for: [])
-        favButton.backgroundColor = UIColor(red: 0.17, green: 0.29, blue: 0.45, alpha: 1.0)
-        favButton.setTitleColor(.white, for: [])
-        favButton.layer.cornerRadius = 4
-        favButton.clipsToBounds = true
-        
-        let replyButton = UIButton(type: .system)
-        replyButton.setTitle("Reply", for: [])
-        replyButton.backgroundColor = favButton.backgroundColor
-        replyButton.setTitleColor(.white, for: [])
-        replyButton.layer.cornerRadius = 4
-        replyButton.clipsToBounds = true
-
-        let headerView = HeaderView()
-
-        // example for View Controller level autolayout with respecting safe area layout guides
         let autolayout = northLayoutFormat(["p": 8, "iconWidth": iconWidth], [
             "header": headerView,
             "icon": iconView,
@@ -70,17 +89,29 @@ class ViewController: UIViewController {
             "reply": replyButton,
             ])
         autolayout("H:|[header]|")
-        autolayout("V:|[header(>=64)]")
+        autolayout("V:|[header(<=192)]")
         autolayout("H:||[icon(==iconWidth)]-p-[name]-p-[date]||")
         autolayout("H:||[text]||")
-        autolayout("H:||[fav]-p-[reply(==fav)]||")
+        autolayout("H:||[reply]-p-[fav(==reply)]||")
         autolayout("V:[header]-p-[icon(==iconWidth)]-p-[text]")
         autolayout("V:[header]-p-[name(==icon)]")
         autolayout("V:[header]-p-[date]")
         autolayout("V:[text]-p-[fav]")
         autolayout("V:[text]-p-[reply]")
+    }
 
-        navigationController?.setNavigationBarHidden(true, animated: true)
+    @objc func nav() {
+        // show/hide navigation bar with animations
+        guard let nc = navigationController else { return }
+        nc.setNavigationBarHidden(!nc.isNavigationBarHidden, animated: true)
+        UIView.animate(withDuration: TimeInterval(UINavigationControllerHideShowBarDuration)) {
+            self.view.setNeedsUpdateConstraints() // not all the layout changes cause updating constraints
+            self.view.layoutIfNeeded() // re-layout within the animation block
+        }
+    }
+
+    @objc func fav() {
+        headerView.bioLabel.text = (headerView.bioLabel.text ?? "") + "\n⭐️"
     }
 }
 
@@ -91,6 +122,7 @@ final class HeaderView: UIView {
         v.backgroundColor = .darkGray
         return v
     }()
+
     let rightColumn: UIView = {
         let v = MinView() // non -1 intrinsic size for compact layout
         v.backgroundColor = .lightGray
@@ -104,6 +136,7 @@ final class HeaderView: UIView {
         v.layer.cornerRadius = 32
         return v
     }()
+
     let nameLabel: UILabel = {
         let l = UILabel(frame: .zero)
         l.text = "@screenname" // @"s" // for short
@@ -111,12 +144,13 @@ final class HeaderView: UIView {
         l.textAlignment = .center
         return l
     }()
+
     let bioLabel: UILabel = {
         let l = UILabel(frame: .zero)
         l.text = "some text"
         l.textColor = .black
         l.backgroundColor = .white
-        l.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
+        l.numberOfLines = 0
         return l
     }()
 
@@ -129,24 +163,19 @@ final class HeaderView: UIView {
         autolayout("V:|[right]|")
         rightColumn.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
 
-        let leftLayout = leftColumn.northLayoutFormat(["p": 8], [
+        let leftLayout = leftColumn.northLayoutFormat([:], [
             "icon": iconView,
             "name": nameLabel])
-        leftLayout("H:[icon(==64)]")
-        leftLayout("V:|-p-[icon(==64)]-p-[name]-p-|")
-        leftColumn.layoutMarginsGuide.leftAnchor.constraint(lessThanOrEqualTo: iconView.leftAnchor).isActive = true
-        leftColumn.layoutMarginsGuide.rightAnchor.constraint(greaterThanOrEqualTo: iconView.rightAnchor).isActive = true
+        leftLayout("H:||-(>=0)-[icon(==64)]-(>=0)-||")
+        leftLayout("H:||-(>=0)-[name]-(>=0)-||")
+        leftLayout("V:||[icon(==64)]-[name]-(>=0)-||")
         leftColumn.layoutMarginsGuide.centerXAnchor.constraint(equalTo: iconView.centerXAnchor).isActive = true
-
-        leftColumn.layoutMarginsGuide.leftAnchor.constraint(lessThanOrEqualTo: nameLabel.leftAnchor).isActive = true
-        leftColumn.layoutMarginsGuide.rightAnchor.constraint(greaterThanOrEqualTo: nameLabel.rightAnchor).isActive = true
         leftColumn.layoutMarginsGuide.centerXAnchor.constraint(equalTo: nameLabel.centerXAnchor).isActive = true
 
-        let rightLayout = rightColumn.northLayoutFormat(["p": 8], [
+        let rightLayout = rightColumn.northLayoutFormat([:], [
             "bio": bioLabel])
-        rightLayout("V:|-p-[bio]-(>=p)-|")
-        rightColumn.layoutMarginsGuide.leftAnchor.constraint(equalTo: bioLabel.leftAnchor).isActive = true
-        rightColumn.layoutMarginsGuide.rightAnchor.constraint(equalTo: bioLabel.rightAnchor).isActive = true
+        rightLayout("H:||[bio]||")
+        rightLayout("V:||[bio]-(>=0)-||")
 
         setContentHuggingPriority(.required, for: .vertical)
     }

--- a/Example/NorthLayout-ios/ViewController.swift
+++ b/Example/NorthLayout-ios/ViewController.swift
@@ -80,6 +80,7 @@ class ViewController: UIViewController {
         super.loadView()
         view.backgroundColor = .white
 
+        // view controller level autolayout respecting safe area layout guides (or top/bottom layout guides for iOS 10 and before)
         let autolayout = northLayoutFormat(["p": 8, "iconWidth": iconWidth], [
             "header": headerView,
             "icon": iconView,

--- a/Example/NorthLayout-ios/ViewController.swift
+++ b/Example/NorthLayout-ios/ViewController.swift
@@ -43,6 +43,7 @@ class ViewController: UIViewController {
         l.font = UIFont.systemFont(ofSize: 12)
         l.textColor = .lightGray
         l.textAlignment = .right
+        l.setContentHuggingPriority(.required, for: .horizontal)
         return l
     }()
 
@@ -98,6 +99,12 @@ class ViewController: UIViewController {
         autolayout("V:[header]-p-[date]")
         autolayout("V:[text]-p-[fav]")
         autolayout("V:[text]-p-[reply]")
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        NSLog("%@", "view.layoutMargins = \(view.layoutMargins)")
+        NSLog("%@", "view._autolayoutTrace = \(String(describing: view.value(forKey: "_autolayoutTrace")))")
     }
 
     @objc func nav() {

--- a/Example/NorthLayout-ios/ViewController.swift
+++ b/Example/NorthLayout-ios/ViewController.swift
@@ -56,8 +56,12 @@ class ViewController: UIViewController {
         replyButton.setTitleColor(.white, for: [])
         replyButton.layer.cornerRadius = 4
         replyButton.clipsToBounds = true
-        
+
+        let headerView = HeaderView()
+
+        // example for View Controller level autolayout with respecting safe area layout guides
         let autolayout = northLayoutFormat(["p": 8, "iconWidth": iconWidth], [
+            "header": headerView,
             "icon": iconView,
             "name": nameLabel,
             "date": dateLabel,
@@ -68,11 +72,86 @@ class ViewController: UIViewController {
         autolayout("H:|-p-[icon(==iconWidth)]-p-[name]-p-[date]-p-|")
         autolayout("H:|-p-[text]-p-|")
         autolayout("H:|-p-[fav]-p-[reply(==fav)]-p-|")
-        autolayout("V:|-p-[icon(==iconWidth)]-p-[text]")
-        autolayout("V:|-p-[name(==icon)]")
-        autolayout("V:|-p-[date]")
+        autolayout("V:[header]-p-[icon(==iconWidth)]-p-[text]")
+        autolayout("V:[header]-p-[name(==icon)]")
+        autolayout("V:[header]-p-[date]")
         autolayout("V:[text]-p-[fav]")
         autolayout("V:[text]-p-[reply]")
+
+        let nonSafeAreaAutolayout = northLayoutFormat([:], ["header": headerView], useSafeArea: false)
+        nonSafeAreaAutolayout("H:|[header]|")
+        nonSafeAreaAutolayout("V:|[header(>=64)]")
+
+        navigationController?.setNavigationBarHidden(true, animated: true)
     }
+}
+
+// Example for view level autolayout with respecting safe area layout guides
+final class HeaderView: UIView {
+    let leftColumn: UIView = {
+        let v = MinView() // non -1 intrinsic size for compact layout
+        v.backgroundColor = .darkGray
+        return v
+    }()
+    let rightColumn: UIView = {
+        let v = MinView() // non -1 intrinsic size for compact layout
+        v.backgroundColor = .lightGray
+        return v
+    }()
+
+    let iconView: UIView = {
+        let v = UIView(frame: .zero)
+        v.backgroundColor = UIColor(red: 0.63, green: 0.9, blue: 1, alpha: 1)
+        v.clipsToBounds = true
+        v.layer.cornerRadius = 32
+        return v
+    }()
+    let nameLabel: UILabel = {
+        let l = UILabel(frame: .zero)
+        l.text = "@screenname" // @"s" // for short
+        l.textColor = .white
+        l.textAlignment = .center
+        return l
+    }()
+    let bioLabel: UILabel = {
+        let l = UILabel(frame: .zero)
+        l.text = "some text"
+        l.textColor = .black
+        l.backgroundColor = .white
+        l.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
+        return l
+    }()
+
+    init() {
+        super.init(frame: .zero)
+
+        let autolayout = northLayoutFormat([:], ["left": leftColumn, "right": rightColumn])
+        autolayout("H:|[left][right]|")
+        autolayout("V:|[left]|")
+        autolayout("V:|[right]|")
+        rightColumn.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
+
+        let leftLayout = leftColumn.northLayoutFormat(["p": 8], [
+            "icon": iconView,
+            "name": nameLabel])
+        leftLayout("H:[icon(==64)]")
+        leftLayout("V:|-p-[icon(==64)]-p-[name]-p-|")
+        leftColumn.layoutMarginsGuide.leftAnchor.constraint(lessThanOrEqualTo: iconView.leftAnchor).isActive = true
+        leftColumn.layoutMarginsGuide.rightAnchor.constraint(greaterThanOrEqualTo: iconView.rightAnchor).isActive = true
+        leftColumn.layoutMarginsGuide.centerXAnchor.constraint(equalTo: iconView.centerXAnchor).isActive = true
+
+        leftColumn.layoutMarginsGuide.leftAnchor.constraint(lessThanOrEqualTo: nameLabel.leftAnchor).isActive = true
+        leftColumn.layoutMarginsGuide.rightAnchor.constraint(greaterThanOrEqualTo: nameLabel.rightAnchor).isActive = true
+        leftColumn.layoutMarginsGuide.centerXAnchor.constraint(equalTo: nameLabel.centerXAnchor).isActive = true
+
+        let rightLayout = rightColumn.northLayoutFormat(["p": 8], [
+            "bio": bioLabel])
+        rightLayout("V:|-p-[bio]-(>=p)-|")
+        rightColumn.layoutMarginsGuide.leftAnchor.constraint(equalTo: bioLabel.leftAnchor).isActive = true
+        rightColumn.layoutMarginsGuide.rightAnchor.constraint(equalTo: bioLabel.rightAnchor).isActive = true
+
+        setContentHuggingPriority(.required, for: .vertical)
+    }
+    required init?(coder aDecoder: NSCoder) {super.init(coder: aDecoder)}
 }
 

--- a/Example/NorthLayout-ios/ViewController.swift
+++ b/Example/NorthLayout-ios/ViewController.swift
@@ -69,18 +69,16 @@ class ViewController: UIViewController {
             "fav": favButton,
             "reply": replyButton,
             ])
-        autolayout("H:|-p-[icon(==iconWidth)]-p-[name]-p-[date]-p-|")
-        autolayout("H:|-p-[text]-p-|")
-        autolayout("H:|-p-[fav]-p-[reply(==fav)]-p-|")
+        autolayout("H:|[header]|")
+        autolayout("V:|[header(>=64)]")
+        autolayout("H:||[icon(==iconWidth)]-p-[name]-p-[date]||")
+        autolayout("H:||[text]||")
+        autolayout("H:||[fav]-p-[reply(==fav)]||")
         autolayout("V:[header]-p-[icon(==iconWidth)]-p-[text]")
         autolayout("V:[header]-p-[name(==icon)]")
         autolayout("V:[header]-p-[date]")
         autolayout("V:[text]-p-[fav]")
         autolayout("V:[text]-p-[reply]")
-
-        let nonSafeAreaAutolayout = northLayoutFormat([:], ["header": headerView], useSafeArea: false)
-        nonSafeAreaAutolayout("H:|[header]|")
-        nonSafeAreaAutolayout("V:|[header(>=64)]")
 
         navigationController?.setNavigationBarHidden(true, animated: true)
     }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - FootlessParser (0.4)
-  - NorthLayout (4.0.0-beta.3):
+  - NorthLayout (4.0.0):
     - FootlessParser (~> 0.4)
 
 DEPENDENCIES:
@@ -12,7 +12,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FootlessParser: 17af528d685057d7a48c3231bbe0a7babb163775
-  NorthLayout: 01e37e9357d0a17a422ddd68c6531d00c61e7f9a
+  NorthLayout: 50c3d3af52e55d39dcf9cfdd28218f9a550f5db1
 
 PODFILE CHECKSUM: 6567cbb1359df4e786c293632327df35bca886b8
 


### PR DESCRIPTION
Introduces `||` layout margin boundary in addition to standard VFL superview boundaries `|`.

`autolayout("H:|[label]|")` describes fit to superview with no margins.

`autolayout("H:||[label]||")` describes fit to superview.layoutMarginsGuide with no margins.

In iOS 11, `layoutMarginsGuide` follows safe area by default and useful for simple definitions with VFL. in iOS 10 and before, `layoutMarginsGuide` does not follow top/bottom layout guides. thus we need top/bottom layout guides trick for iOS 10 and before, as supported in NorthLayout 4 and before.

## What constraints can be defined with this PR

* As layoutMarginsGuide follows Safe Area, we get safe area support for almost free.

* We can use single `northlayoutFormat` to define constraints both for layout margins bound (= safe area, nearly) and superview bound (= screen bound).

* Even more, we can separate layout logic into view controller and view. Thanks to safe area awareness of UIView (in contrast to UIViewController), UIView itself can define its layout with safe area layout guides. UIViewController does not have to setup constraints between safe area layout guides and views of subviews (in iOS 11).
